### PR TITLE
PROMETEUS EC2 TRAFFIC

### DIFF
--- a/helm/argocd/values.yaml
+++ b/helm/argocd/values.yaml
@@ -61,7 +61,7 @@ clusters:
     kind: helm
     namespace: monitoring-prometheus
     environments:
-    # - ${ENVIRONMENT-NAME}
+    - prometheus-ec2-traffic
     - prometheus-ec2-catalog
     - prometheus-ec2-logistics
     - prometheus-ec2-orders

--- a/prometheus-ec2/b.yaml
+++ b/prometheus-ec2/b.yaml
@@ -100,9 +100,9 @@ prometheus:
             - source_labels: [__meta_ec2_instance_id]
               target_label: instance
               action: replace
-            # - source_labels: [__meta_ec2_tag_Product]
-            #   regex: "${PRODUCT-TAGS}"
-            #   action: drop
+            - source_labels: [__meta_ec2_tag_Product]
+              regex: "arquivos|srv-arquivos|filemanager"
+              action: drop
             - source_labels: [__meta_ec2_tag_Product]
               regex: "checkout-instore|chk-app|checkout-ui|Checkout|srv-checkout|vtex-checkout|checkout"
               action: drop
@@ -181,9 +181,9 @@ prometheus:
             - source_labels: [__meta_ec2_platform]
               regex: windows
               action: drop
-            # - source_labels: [__meta_ec2_tag_Product]
-            #   regex: "${PRODUCT-TAGS}"
-            #   action: drop
+            - source_labels: [__meta_ec2_tag_Product]
+              regex: "arquivos|srv-arquivos|filemanager"
+              action: drop
             - source_labels: [__meta_ec2_tag_Product]
               regex: "checkout-instore|chk-app|checkout-ui|Checkout|srv-checkout|vtex-checkout|checkout"
               action: drop
@@ -254,9 +254,9 @@ prometheus:
             - source_labels: [__meta_ec2_instance_id]
               target_label: instance
               action: replace
-            # - source_labels: [__meta_ec2_tag_Product]
-            #   regex: "${PRODUCT-TAGS}"
-            #   action: drop
+            - source_labels: [__meta_ec2_tag_Product]
+              regex: "arquivos|srv-arquivos|filemanager"
+              action: drop
             - source_labels: [__meta_ec2_tag_Product]
               regex: "checkout-instore|chk-app|checkout-ui|Checkout|srv-checkout|vtex-checkout|checkout"
               action: drop

--- a/prometheus-ec2/ca.yaml
+++ b/prometheus-ec2/ca.yaml
@@ -101,9 +101,9 @@ prometheus:
             - source_labels: [__meta_ec2_instance_id]
               target_label: instance
               action: replace
-            # - source_labels: [__meta_ec2_tag_Product]
-            #   regex: "${PRODUCT-TAGS}"
-            #   action: drop
+            - source_labels: [__meta_ec2_tag_Product]
+              regex: "arquivos|srv-arquivos|filemanager"
+              action: drop
             - source_labels: [__meta_ec2_tag_Product]
               regex: "checkout-instore|chk-app|checkout-ui|Checkout|srv-checkout|vtex-checkout|checkout"
               action: drop
@@ -183,9 +183,9 @@ prometheus:
             - source_labels: [__meta_ec2_platform]
               regex: windows
               action: drop
-            # - source_labels: [__meta_ec2_tag_Product]
-            #   regex: "${PRODUCT-TAGS}"
-            #   action: drop
+            - source_labels: [__meta_ec2_tag_Product]
+              regex: "arquivos|srv-arquivos|filemanager"
+              action: drop
             - source_labels: [__meta_ec2_tag_Product]
               regex: "checkout-instore|chk-app|checkout-ui|Checkout|srv-checkout|vtex-checkout|checkout"
               action: drop
@@ -257,9 +257,9 @@ prometheus:
             - source_labels: [__meta_ec2_instance_id]
               target_label: instance
               action: replace
-            # - source_labels: [__meta_ec2_tag_Product]
-            #   regex: "${PRODUCT-TAGS}"
-            #   action: drop
+            - source_labels: [__meta_ec2_tag_Product]
+              regex: "arquivos|srv-arquivos|filemanager"
+              action: drop
             - source_labels: [__meta_ec2_tag_Product]
               regex: "checkout-instore|chk-app|checkout-ui|Checkout|srv-checkout|vtex-checkout|checkout"
               action: drop

--- a/prometheus-ec2/d.yaml
+++ b/prometheus-ec2/d.yaml
@@ -100,9 +100,9 @@ prometheus:
             - source_labels: [__meta_ec2_instance_id]
               target_label: instance
               action: replace
-            # - source_labels: [__meta_ec2_tag_Product]
-            #   regex: "${PRODUCT-TAGS}"
-            #   action: drop
+            - source_labels: [__meta_ec2_tag_Product]
+              regex: "arquivos|srv-arquivos|filemanager"
+              action: drop
             - source_labels: [__meta_ec2_tag_Product]
               regex: "checkout-instore|chk-app|checkout-ui|Checkout|srv-checkout|vtex-checkout|checkout"
               action: drop
@@ -181,9 +181,9 @@ prometheus:
             - source_labels: [__meta_ec2_platform]
               regex: windows
               action: drop
-            # - source_labels: [__meta_ec2_tag_Product]
-            #   regex: "${PRODUCT-TAGS}"
-            #   action: drop
+            - source_labels: [__meta_ec2_tag_Product]
+              regex: "arquivos|srv-arquivos|filemanager"
+              action: drop
             - source_labels: [__meta_ec2_tag_Product]
               regex: "checkout-instore|chk-app|checkout-ui|Checkout|srv-checkout|vtex-checkout|checkout"
               action: drop
@@ -254,9 +254,9 @@ prometheus:
             - source_labels: [__meta_ec2_instance_id]
               target_label: instance
               action: replace
-            # - source_labels: [__meta_ec2_tag_Product]
-            #   regex: "${PRODUCT-TAGS}"
-            #   action: drop
+            - source_labels: [__meta_ec2_tag_Product]
+              regex: "arquivos|srv-arquivos|filemanager"
+              action: drop
             - source_labels: [__meta_ec2_tag_Product]
               regex: "checkout-instore|chk-app|checkout-ui|Checkout|srv-checkout|vtex-checkout|checkout"
               action: drop

--- a/prometheus-ec2/e.yaml
+++ b/prometheus-ec2/e.yaml
@@ -100,9 +100,9 @@ prometheus:
             - source_labels: [__meta_ec2_instance_id]
               target_label: instance
               action: replace
-            # - source_labels: [__meta_ec2_tag_Product]
-            #   regex: "${PRODUCT-TAGS}"
-            #   action: drop
+            - source_labels: [__meta_ec2_tag_Product]
+              regex: "arquivos|srv-arquivos|filemanager"
+              action: drop
             - source_labels: [__meta_ec2_tag_Product]
               regex: "checkout-instore|chk-app|checkout-ui|Checkout|srv-checkout|vtex-checkout|checkout"
               action: drop
@@ -181,9 +181,9 @@ prometheus:
             - source_labels: [__meta_ec2_platform]
               regex: windows
               action: drop
-            # - source_labels: [__meta_ec2_tag_Product]
-            #   regex: "${PRODUCT-TAGS}"
-            #   action: drop
+            - source_labels: [__meta_ec2_tag_Product]
+              regex: "arquivos|srv-arquivos|filemanager"
+              action: drop
             - source_labels: [__meta_ec2_tag_Product]
               regex: "checkout-instore|chk-app|checkout-ui|Checkout|srv-checkout|vtex-checkout|checkout"
               action: drop
@@ -254,9 +254,9 @@ prometheus:
             - source_labels: [__meta_ec2_instance_id]
               target_label: instance
               action: replace
-            # - source_labels: [__meta_ec2_tag_Product]
-            #   regex: "${PRODUCT-TAGS}"
-            #   action: drop
+            - source_labels: [__meta_ec2_tag_Product]
+              regex: "arquivos|srv-arquivos|filemanager"
+              action: drop
             - source_labels: [__meta_ec2_tag_Product]
               regex: "checkout-instore|chk-app|checkout-ui|Checkout|srv-checkout|vtex-checkout|checkout"
               action: drop

--- a/prometheus-ec2/f.yaml
+++ b/prometheus-ec2/f.yaml
@@ -100,9 +100,9 @@ prometheus:
             - source_labels: [__meta_ec2_instance_id]
               target_label: instance
               action: replace
-            # - source_labels: [__meta_ec2_tag_Product]
-            #   regex: "${PRODUCT-TAGS}"
-            #   action: drop
+            - source_labels: [__meta_ec2_tag_Product]
+              regex: "arquivos|srv-arquivos|filemanager"
+              action: drop
             - source_labels: [__meta_ec2_tag_Product]
               regex: "checkout-instore|chk-app|checkout-ui|Checkout|srv-checkout|vtex-checkout|checkout"
               action: drop
@@ -181,9 +181,9 @@ prometheus:
             - source_labels: [__meta_ec2_platform]
               regex: windows
               action: drop
-            # - source_labels: [__meta_ec2_tag_Product]
-            #   regex: "${PRODUCT-TAGS}"
-            #   action: drop
+            - source_labels: [__meta_ec2_tag_Product]
+              regex: "arquivos|srv-arquivos|filemanager"
+              action: drop
             - source_labels: [__meta_ec2_tag_Product]
               regex: "checkout-instore|chk-app|checkout-ui|Checkout|srv-checkout|vtex-checkout|checkout"
               action: drop
@@ -254,9 +254,9 @@ prometheus:
             - source_labels: [__meta_ec2_instance_id]
               target_label: instance
               action: replace
-            # - source_labels: [__meta_ec2_tag_Product]
-            #   regex: "${PRODUCT-TAGS}"
-            #   action: drop
+            - source_labels: [__meta_ec2_tag_Product]
+              regex: "arquivos|srv-arquivos|filemanager"
+              action: drop
             - source_labels: [__meta_ec2_tag_Product]
               regex: "checkout-instore|chk-app|checkout-ui|Checkout|srv-checkout|vtex-checkout|checkout"
               action: drop


### PR DESCRIPTION
Prometheus ec2 migration to AMP for traffic
Drops metrics in prometheus ec2.
Adds new environment to argocd.